### PR TITLE
fix(`create`): check if the working tree is clean before creating branch

### DIFF
--- a/src/subcommands/local/create.rs
+++ b/src/subcommands/local/create.rs
@@ -25,6 +25,11 @@ impl CreateCmd {
             None => inquire::Text::new("Name of new branch:").prompt()?,
         };
 
+        // Check if the working tree is clean.
+        if !ctx.repository.is_working_tree_clean()? {
+            return Err(crate::errors::StError::WorkingTreeDirty);
+        }
+
         // Attempt to create the new branch.
         ctx.repository
             .branch(&new_branch_name, &current_branch_head, false)?;


### PR DESCRIPTION
Fixes #25. Note that this doesn't remove the repeated dirty check on `checkout_branch` on purpose—lmk if this needs changing