### PR TITLE
chore(config): update default description with instructions for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
 
 ## Installation
 
+> \[!WARNING\]
+> `st` was written on a weekend for my own personal use, and may not be entirely stable. You're welcome to use it
+> in its current state, though don't get mad at me if the tool messes up your local tree. I'll remove this warning once
+> I feel that it's stable for my own usecase.
+
 You can install `st` with:
 
 ```sh

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub(crate) const DEFAULT_CONFIG_PRETTY: &str = r#"# GitHub personal access token
 # Must have the following scopes:
 # - repo:status
 # - repo:public_repo
+#
+# If you're planning to use st with private repositories, you'll need to add the full `repo` scope.
 github_token = """#;
 
 #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
On private repos, st needs the full `repo` scope to work properly--else you'll get a 404. It should say so in the config.

EDIT: Unsure why github messed up my fork history? 😅 