### PR TITLE
Config cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@
 
 ## Installation
 
+> \[!WARNING\]
+> `st` was written on a weekend for my own personal use, and may not be entirely stable. You're welcome to use it
+> in its current state, though don't get mad at me if the tool messes up your local tree. I'll remove this warning once
+> I feel that it's stable for my own usecase.
+
 You can install `st` with:
 
 ```sh
 git clone https://github.com/clabby/st && \
    cd st && \
-   cargo install --bin st --force
+   cargo install --bin st --path . --force
 ```
 
 ## What are Stacked PRs?

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Contains the global configuration for `st`.
 
-use crate::constants::ST_CFG_FILE_NAME;
+use crate::{constants::ST_CFG_FILE_NAME, errors::StResult};
+use nu_ansi_term::Color;
 use serde::{Deserialize, Serialize};
 use std::{fs, io, path::PathBuf};
 use thiserror::Error;
@@ -37,9 +38,19 @@ impl StConfig {
         }
     }
 
-    pub fn save(&self) -> Result<(), io::Error> {
+    /// Validates the configuration.
+    pub fn validate(&self) -> Result<(), StConfigError> {
+        if self.github_token.is_empty() {
+            return Err(StConfigError::MissingField("github_token".to_string()));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for StConfig {
+    fn drop(&mut self) {
         let config_path = PathBuf::from(env!("HOME")).join(ST_CFG_FILE_NAME);
-        fs::write(&config_path, toml::to_string(self).unwrap())
+        fs::write(&config_path, toml::to_string(self).unwrap()).unwrap();
     }
 }
 
@@ -49,6 +60,35 @@ pub enum StConfigError {
     /// Failed to load the configuration file.
     #[error("Failed to load the configuration file: {}", .0)]
     FailedToLoad(io::Error),
+    /// Missing a reqired field.
+    #[error("Missing required field: {}", .0)]
+    MissingField(String),
+}
+
+/// Prompts the user to set up the global configuration for `st`.
+///
+/// ## Returns
+/// - `Result<StConfig>` - The newly created global `st` config.
+pub fn prompt_for_configuration(existing_config: Option<&str>) -> StResult<StConfig> {
+    let setup_text = format!(
+        "{} configuration found for `{}`. Set up the environment.",
+        existing_config.map(|_| "Existing").unwrap_or("No"),
+        Color::Blue.paint("st")
+    );
+
+    // Use the provided predefined text or fall back to the default.
+    let default_text = existing_config.unwrap_or(DEFAULT_CONFIG_PRETTY);
+
+    // Print the default config.
+    let ser_cfg = inquire::Editor::new(&setup_text)
+        .with_file_extension(".toml")
+        .with_predefined_text(default_text)
+        .prompt()?;
+
+    let config: StConfig = toml::from_str(&ser_cfg)?;
+    config.validate()?;
+
+    Ok(config)
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,12 +36,10 @@ impl StConfig {
             Err(_) => Ok(None),
         }
     }
-}
 
-impl Drop for StConfig {
-    fn drop(&mut self) {
+    pub fn save(&self) -> Result<(), io::Error> {
         let config_path = PathBuf::from(env!("HOME")).join(ST_CFG_FILE_NAME);
-        fs::write(&config_path, toml::to_string(self).unwrap()).unwrap();
+        fs::write(&config_path, toml::to_string(self).unwrap())
     }
 }
 

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -4,9 +4,11 @@ use crate::{
     config::StConfig,
     constants::{GIT_DIR, ST_CTX_FILE_NAME},
     errors::{StError, StResult},
+    git::RepositoryExt,
     tree::StackTree,
 };
 use git2::{BranchType, Repository};
+use octocrab::Octocrab;
 use std::path::PathBuf;
 
 mod actions;
@@ -45,6 +47,42 @@ impl<'a> StContext<'a> {
             repository,
             tree: StackTree::new(trunk),
         }
+    }
+
+    /// Returns if the current branch has an open PR.
+    /// Returns the branch name and it's parent branch name.
+    pub async fn get_open_pr(&self, client: &Octocrab) -> StResult<Option<(String, String)>> {
+        let (owner, repo) = self.owner_and_repository()?;
+        let page = client
+            .pulls(&owner, &repo)
+            .list()
+            .state(octocrab::params::State::Open)
+            .sort(octocrab::params::pulls::Sort::Popularity)
+            .direction(octocrab::params::Direction::Ascending)
+            .per_page(255)
+            .send()
+            .await?;
+        let mut found = false;
+        let current_branch = self.repository.current_branch_name()?;
+        for item in page.items.iter() {
+            if item.head.ref_field == current_branch {
+                found = true;
+                break;
+            }
+        }
+        if found {
+            let current_tracked_branch = self
+                .tree
+                .get(&current_branch)
+                .ok_or_else(|| StError::BranchNotTracked(current_branch.to_string()))?;
+            let upstack = current_tracked_branch.parent.as_ref();
+            return Ok(Some((
+                current_branch,
+                upstack.map(|s| s.as_ref()).unwrap_or("unknown").to_string(),
+            )));
+        }
+
+        Ok(None)
     }
 
     /// Loads the [StackTree] for the given [Repository], and assembles a [StContext].

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,7 +84,7 @@ pub enum StError {
     #[error("🖋️ write error: {}", .0)]
     WriteError(#[from] std::fmt::Error),
     /// A [toml::ser::Error] occurred.
-    #[error("🍅 toml decoding error: {}", .0)]
+    #[error("🍅 toml serialization error: {}", .0)]
     TomlSerializationError(#[from] toml::ser::Error),
     /// A [toml::de::Error] occurred.
     #[error("🍅 toml decoding error: {}", .0)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -83,6 +83,9 @@ pub enum StError {
     /// A [std::fmt::Write] error occurred.
     #[error("🖋️ write error: {}", .0)]
     WriteError(#[from] std::fmt::Error),
+    /// A [toml::ser::Error] occurred.
+    #[error("🍅 toml decoding error: {}", .0)]
+    TomlSerializationError(#[from] toml::ser::Error),
     /// A [toml::de::Error] occurred.
     #[error("🍅 toml decoding error: {}", .0)]
     TomlDecodingError(#[from] toml::de::Error),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,6 +43,9 @@ pub enum StError {
     /// A remote pull request could not be found.
     #[error("Remote pull request not found.")]
     PullRequestNotFound,
+    /// A pull request is already open.
+    #[error("Pull request is already open for branch {} with parent `{}`.", Color::Blue.paint(.0), Color::Blue.paint(.1))]
+    PullRequestAlreadyOpen(String, String),
 
     // ---- [ Git Errors ] ----
     /// `st` mused be run within a git repository.

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -38,9 +38,6 @@ pub enum StError {
     /// A generic decoding error occurred.
     #[error("Decoding error: {}", .0)]
     DecodingError(String),
-    /// The configuration is not correctly initialized.
-    #[error("Configuration not initialized. Please edit configuration at: {}", .0)]
-    ConfigNotInitialized(String),
 
     // ---- [ `st` application errors (remote) ] ----
     /// A remote pull request could not be found.

--- a/src/subcommands/local/config.rs
+++ b/src/subcommands/local/config.rs
@@ -7,8 +7,6 @@ use crate::{
     errors::{StError, StResult},
 };
 use clap::Args;
-use cli_table::{Cell, Style, Table};
-use octocrab::{models::IssueState, Octocrab};
 use std::path::PathBuf;
 
 /// CLI arguments for the `config` subcommand.

--- a/src/subcommands/local/config.rs
+++ b/src/subcommands/local/config.rs
@@ -1,29 +1,17 @@
 //! `config` subcommand.
 
-use crate::{cli::Cli, config::StConfig, ctx::StContext, errors::StResult};
-use inquire::Confirm;
+use crate::{config::prompt_for_configuration, ctx::StContext, errors::StResult};
 
 #[derive(Debug, Clone, Eq, PartialEq, clap::Args)]
 pub struct ConfigCmd;
 
 impl ConfigCmd {
     /// Run the `config` subcommand to force or allow configuration editing.
-    pub fn run(self, _ctx: StContext<'_>) -> StResult<()> {
-        let config = Cli::load_cfg_or_initialize()?;
-        if config == StConfig::default() || config.github_token.is_empty() {
-            println!("Configuration is not initialized. Please configure it now.");
-            Cli::prompt_for_configuration("")?;
-        } else {
-            let parsed_config = toml::to_string_pretty(&config).unwrap();
-            println!("Current configuration:\n\n{}", parsed_config);
-            if Confirm::new("Do you want to edit the configuration? (default: no)")
-                .with_default(false)
-                .prompt()?
-            {
-                Cli::prompt_for_configuration(&parsed_config)?;
-                println!("Configuration updated.");
-            }
-        }
+    pub fn run(self, mut ctx: StContext<'_>) -> StResult<()> {
+        let ser = toml::to_string_pretty(&ctx.cfg)?;
+        let cfg = prompt_for_configuration(Some(&ser))?;
+        ctx.cfg = cfg;
+
         Ok(())
     }
 }

--- a/src/subcommands/local/config.rs
+++ b/src/subcommands/local/config.rs
@@ -26,7 +26,10 @@ impl ConfigCmd {
                 config_path.display().to_string(),
             ));
         } else {
-            println!("Configuration successfully initialized at: {:?}", config_path);
+            println!(
+                "Configuration successfully initialized at: {:?}",
+                config_path
+            );
         }
 
         Ok(())


### PR DESCRIPTION
Added a config command that helps provide more insight into how to configure st. Right now, if st.toml isn't configured correctly it directs the user to open the file by printing the file to the terminal.

One kind of annoying thing right now is the double prompt if you already have existing configuration: 
![CleanShot 2024-10-24 at 18 39 22@2x](https://github.com/user-attachments/assets/318a66c7-7825-476e-8566-ef7b7d1042c6)
Maybe that could be a separate issue. 

