### PR TITLE
fix(cli): Don't prevent updating branches of remote PRs

### DIFF
--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -4,11 +4,9 @@ use crate::{
     config::StConfig,
     constants::{GIT_DIR, ST_CTX_FILE_NAME},
     errors::{StError, StResult},
-    git::RepositoryExt,
     tree::StackTree,
 };
 use git2::{BranchType, Repository};
-use octocrab::Octocrab;
 use std::path::PathBuf;
 
 mod actions;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -43,9 +43,6 @@ pub enum StError {
     /// A remote pull request could not be found.
     #[error("Remote pull request not found.")]
     PullRequestNotFound,
-    /// A pull request is already open.
-    #[error("Pull request is already open for branch {} with parent `{}`.", Color::Blue.paint(.0), Color::Blue.paint(.1))]
-    PullRequestAlreadyOpen(String, String),
 
     // ---- [ Git Errors ] ----
     /// `st` mused be run within a git repository.

--- a/src/subcommands/remote/submit.rs
+++ b/src/subcommands/remote/submit.rs
@@ -34,7 +34,7 @@ impl SubmitCmd {
 
         // Perform pre-flight checks.
         println!("🔍 Checking for closed pull requests...");
-        self.pre_flight(&gh_client, &mut ctx, &stack, &mut pulls)
+        self.pre_flight(&mut ctx, &stack, &mut pulls)
             .await?;
 
         // Submit the stack.
@@ -57,18 +57,12 @@ impl SubmitCmd {
     /// Performs pre-flight checks before submitting the stack.
     async fn pre_flight(
         &self,
-        gh_client: &Octocrab,
         ctx: &mut StContext<'_>,
         stack: &[String],
         pulls: &mut PullRequestHandler<'_>,
     ) -> StResult<()> {
         // Return early if the stack is not restacked or the current working tree is dirty.
         ctx.check_cleanliness(stack)?;
-
-        // Check if the current branch has an open PR.
-        if let Some((c, p)) = ctx.get_open_pr(gh_client).await? {
-            return Err(StError::PullRequestAlreadyOpen(c, p));
-        }
 
         // Check if any PRs have been closed, and offer to delete them before starting the submission process.
         let num_closed = ctx

--- a/src/subcommands/remote/submit.rs
+++ b/src/subcommands/remote/submit.rs
@@ -34,8 +34,7 @@ impl SubmitCmd {
 
         // Perform pre-flight checks.
         println!("🔍 Checking for closed pull requests...");
-        self.pre_flight(&mut ctx, &stack, &mut pulls)
-            .await?;
+        self.pre_flight(&mut ctx, &stack, &mut pulls).await?;
 
         // Submit the stack.
         println!(


### PR DESCRIPTION
## Overview

There was a small UX bug introduced in https://github.com/clabby/st/pull/18 where `st submit` couldn't update branches with open PRs.

This temporarily reverts those changes so that they can be resubmitted with a fix.